### PR TITLE
removed client_secret from refresh_token grant_type 

### DIFF
--- a/oauth2lib/provider.py
+++ b/oauth2lib/provider.py
@@ -500,15 +500,11 @@ class AuthorizationProvider(Provider):
         })
 
 
-    def get_token_for_refresh_token(self, client_id, client_secret,
-                  refresh_token,
-                  **params):
+    def get_token_for_refresh_token(self, client_id, refresh_token, **params):
         """Generate access token HTTP response.
 
         :param client_id: Client ID.
         :type client_id: str
-        :param client_secret: Client secret.
-        :type client_secret: str
         :param redirect_uri: Client redirect URI.
         :type redirect_uri: str
         :param code: Authorization code.
@@ -518,6 +514,7 @@ class AuthorizationProvider(Provider):
 
         # Check conditions
         # Return proper error responses on invalid conditions
+        client_secret = params.get('client_secret', '')
         client_app = self.validate_client_secret(client_id, client_secret)
         if not client_app:
             return self._make_json_error_response('invalid_client')
@@ -618,7 +615,6 @@ class AuthorizationProvider(Provider):
 
 
             if grant_type == 'authorization_code':
-
                 # Verify OAuth 2.0 Parameters
                 for x in ['client_id', 'client_secret', 'redirect_uri']:
                     if not data.get(x):
@@ -627,7 +623,7 @@ class AuthorizationProvider(Provider):
 
             if grant_type == 'refresh_token':
                 # Verify OAuth 2.0 Parameters
-                for x in ['client_id', 'client_secret', 'refresh_token']:
+                for x in ['client_id', 'refresh_token']:
                     if not data.get(x):
                         raise TypeError("Missing required OAuth 2.0 POST param: {0}".format(x))
                 return self.get_token_for_refresh_token(**data)


### PR DESCRIPTION
it's optional for clients without client_secret (like refresh_tokens obtained by the password grant)

Hi there, you might be interested in this fix. It's usefull if you use a js webapp and authenticate using the password grant. After the timeout, you won't be able to refresh the access_token using the refresh_token.

As discribed in the rfc, the client_secret is only for confidential clients which used client_secret.
https://tools.ietf.org/html/rfc6749#section-6

Usage:

I check in validate_client_secret if this is a client which was registered as client with client_id and password or if its a client_id generated after login with credentials - I only check the secret if its a registered client

The same for validate_client_id
it returns true if its a registered client or a client which was generated after successfull passwort auth

Thanks for your library improvements about grant_type. safed me a lot of time ;)

Marvin
